### PR TITLE
Add files for distribution of the module on Pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Environments
+.venv
+.vscode
+.git

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,2 @@
+License to be chosen by author.
+MIT License could be adapted here.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+description-file=README.md
+license_files=LICENSE.txt   

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, find_packages
+
+
+setup(
+    name='pyMoosh',
+    version='1.0',
+    license='TBD',
+    author="Antoine Moreau",
+    author_email='antoine.moreau@univ-bpclermont.fr',
+    packages=find_packages('code'),
+    package_dir={'': 'code'},
+    url='https://github.com/AnMoreau/PyMoosh',
+    keywords=['Moosh','Maxwell','Scattering','Plasmons'],
+    install_requires=[
+          'numpy',
+      ],
+
+)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version='1.0',
     license='TBD',
     author="Antoine Moreau",
-    author_email='antoine.moreau@univ-bpclermont.fr',
+    author_email='antoine.moreau@uca.fr',
     packages=find_packages('code'),
     package_dir={'': 'code'},
     url='https://github.com/AnMoreau/PyMoosh',


### PR DESCRIPTION
For the users to be able to access pyMoosh with a simple `pip install pymoosh` we need to distribute the module to pypi.
The files added here are required for this matter. 
For more information about the process and what to do next check this page : https://towardsdatascience.com/how-to-upload-your-python-package-to-pypi-de1b363a1b3
