### PR TITLE
Fixed bug in materials.py: replaced orphaned variable "CustomDatabase…

### DIFF
--- a/PyMoosh/materials.py
+++ b/PyMoosh/materials.py
@@ -73,8 +73,8 @@ class Material:
                     self.sigma = np.array(material_data["sigma"])
 
                 elif model == "CustomFunction":
-                    self.type = "CustomDatabaseFunction"
-                    self.name = "CustomDatabaseFunction: " + str(mat)
+                    self.type = "CustomFunction"
+                    self.name = "CustomFunction: " + str(mat)
                     permittivity = material_data["function"]
                     self.permittivity_function = authorized[permittivity]
 


### PR DESCRIPTION
Fixed bug in materials.py: replaced orphaned variable "CustomDatabaseFunction" with correct variable "CustomFunction".

This ensures Material.get_permittivity works for "CustomFunction" materials. (Currently "Glass" is the only member of this type.)