### PR TITLE
Add documentation from notebooks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+# This file was created automatically with `jupyter-book init --gh-pages` 🪄 💚
+# Ensure your GitHub Pages settings for this repository are set to deploy with **GitHub Actions**.
+
+name: Jupyter Book (via myst) GitHub Pages Deploy
+on:
+  push:
+    # Runs on pushes targeting the default branch
+    branches: [main]
+env:
+  # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
+  # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.
+  # If, instead, your site lives at the root of the domain, at `https://mydomain.org`, set `BASE_URL=''`.
+  BASE_URL: /${{ github.event.repository.name }}
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+      - name: Install Jupyter Book (via myst)
+        run: npm install -g jupyter-book
+      - name: Build HTML Assets
+        run: jupyter-book build --html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './_build/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Jupyter Book (via myst) GitHub Pages Deploy
 on:
   push:
     # Runs on pushes targeting the default branch
-    branches: [main]
+    branches: [stable]
 env:
   # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
   # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Fig/*
 *.svg
 TODO.txt
 tests/*
+
+# MyST build outputs
+_build

--- a/myst.yml
+++ b/myst.yml
@@ -1,0 +1,15 @@
+# See docs at: https://mystmd.org/guide/frontmatter
+version: 1
+project:
+  id: 35d0ad15-d16d-4ba6-b6a0-d74bbaa9d6f0
+  # title:
+  # description:
+  # keywords: []
+  # authors: []
+  github: https://github.com/benvial/PyMoosh
+  # To autogenerate a Table of Contents, run "jupyter book init --write-toc"
+site:
+  template: book-theme
+  options:
+    favicon: pymoosh_logo.png
+    logo: pymoosh_logo.png

--- a/myst.yml
+++ b/myst.yml
@@ -6,7 +6,7 @@ project:
   # description:
   # keywords: []
   # authors: []
-  github: https://github.com/benvial/PyMoosh
+  github: https://github.com/AnMoreau/PyMoosh
   # To autogenerate a Table of Contents, run "jupyter book init --write-toc"
 site:
   template: book-theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 ]
 
 
+
 [project.urls]
 Homepage = "https://github.com/AnMoreau/PyMoosh"
 Repository = "https://github.com/AnMoreau/PyMoosh/stable"
@@ -34,6 +35,17 @@ Documentation = "https://github.com/AnMoreau/PyMoosh#readme"
 
 [tool.setuptools.packages.find]
 include = ["PyMoosh*"]
+
+
+[project.optional-dependencies]
+docs = [
+    "jupyter-book",
+]
+
+dev = [
+    "pytest",
+]
+
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
First thanks for the nice package!

This PR sets up automated documentation building and deployment using Jupyter Book and GitHub Pages. The  documentation will automatically publish whenever pushing to the `stable` branch.

Note: Enabling the CI Action in GitHub UI

1. Go to the repository **Settings** → **Pages**
2. Under "Build and deployment", set **Source** to **"GitHub Actions"**
3. Done! The workflow will run automatically on the next push.

The docs should be live at https://AnMoreau.github.io/PyMoosh